### PR TITLE
Fix duplicate manager initialization in ChallengeApp

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -30,15 +30,7 @@ class ChallengeApp {
        this.leaderboardManager = new LeaderboardManager(this);
        this.statsManager = new StatsManager(this);
 
-      // Managers
-this.authManager = new AuthManager(this);
-this.challengeManager = new ChallengeManager(this);
-this.progressManager = new ProgressManager(this);
-this.eventHandler = new EventHandler(this);
-this.statsManager = new StatsManager(this);
-this.renderer = new Renderer(this);  // ADD THIS LINE
-       
-       this.init();
+      this.init();
        
        // Make app globally accessible
        window.app = this;


### PR DESCRIPTION
## Summary
- clean up `public/app.js` by removing repeated instantiation of manager classes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685d4db22a3c8325afa641d3fff5b9d0